### PR TITLE
chore: use public repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "types": "dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/alexkravets/schema.git"
+    "url": "git+https://github.com/alexkravets/schema.git"
   },
   "directories": {
     "src": "src"


### PR DESCRIPTION
## Summary

- replace the SSH repository URL with a public HTTPS URL
- let npm tooling and consumers resolve the source without GitHub SSH credentials

This is a metadata-only change with no runtime code, dependency, or lockfile changes.

## Validation

- ESLint passed
- TypeScript build passed
- Jest: 19 suites / 693 tests passed when excluding `createSchemasMap.test.ts`
- Full Jest run: 702 tests passed; 11 existing assertions in `createSchemasMap.test.ts` fail on Windows because generated map keys contain absolute backslash paths instead of filename-only IDs
- `pnpm pack --dry-run --json --config.ignore-scripts=true` passed after the separate build
- direct package metadata assertion passed
- `git diff --check` passed